### PR TITLE
RG-45 delete i18n from nextjs config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,11 +4,7 @@ const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  i18n: {
-    locales: ['en-US', 'es'],
-    defaultLocale: 'en-US',
-    localeDetection: false,
-  },
+
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
1. Acceptance criteria:

- no errors/warnings about i18n during running app


2. Screenshot min and max layout (not technical tasks): 
<img width="816" alt="image" src="https://github.com/user-attachments/assets/af43678d-75f0-439c-9cd4-1d3ee280cf7a">

4. Comments
Error fixed bc I did not apply any routing to i18n, all others types of routing needs middleware, like - https://next-intl-docs.vercel.app/docs/routing/middleware

# DoD:

- [x] semantic layout

- [ ] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
