### PR TITLE
fix: correct burger menu view

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -8,7 +8,7 @@
   max-width: 800px;
   margin: 0 auto;
   border-radius: 5px;
-  padding: 6rem;
+  padding: 1rem;
   transition: 0.5s;
 }
 

--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -1,7 +1,7 @@
 .header {
   position: sticky;
   display: flex;
-  background-color: rgba(19, 18, 18, 0.664);
+  background-color: rgba(19, 18, 18, 0.781);
   top: 0;
 }
 
@@ -18,9 +18,11 @@
   0% {
     transform: scale(1);
   }
+
   50% {
     transform: scale(1.1);
   }
+
   100% {
     transform: scale(1);
   }
@@ -48,6 +50,17 @@
   height: 3px;
   background-color: #a5a5a5;
   transition: all 0.3s ease;
+}
+
+.burger:hover {
+  span {
+    background-color: #ffae68;
+  }
+
+  .burgerOpen:nth-child(1),
+  .burgerOpen:nth-child(3) {
+    background-color: #ffae68;
+  }
 }
 
 .burgerOpen {
@@ -86,7 +99,7 @@
   top: 100%;
   left: 0;
   width: 100%;
-  background-color: rgba(235, 235, 235, 0.548);
+  padding-bottom: 0;
   z-index: 2;
 }
 
@@ -95,6 +108,7 @@
     max-height: 0;
     opacity: 0;
   }
+
   to {
     max-height: 300px;
     opacity: 1;
@@ -112,6 +126,7 @@
   background: none;
   padding: 15px;
   cursor: pointer;
+
   &:hover {
     color: rgb(233, 150, 26);
   }
@@ -128,6 +143,25 @@
 
   .menuOpen {
     display: flex;
-    background-color: rgba(90, 90, 90, 0.664);
+    background: linear-gradient(180deg, rgba(19, 18, 18, 0.781), rgba(136, 75, 5, 0.836));
+    padding-bottom: 45px;
+  }
+}
+
+@media (min-width: 501px) {
+  .menu {
+    display: flex;
+    flex-direction: row;
+    position: static;
+    width: auto;
+    background-color: transparent;
+  }
+
+  .menuOpen {
+    animation: none;
+  }
+
+  .burger {
+    display: none;
   }
 }


### PR DESCRIPTION
STR:

1. make browser width = 500px to view burger menu
2. open burger menu
3. make browser width  more then 500px

Problem:

- the burger menu still on the screen

_____________________________________________

1. Acceptance criteria:
- the burger menu should be closed and transformed to common view

2. Screenshot min and max layout (not technical tasks):
![localhost_3000_(iPhone 13 mini)](https://github.com/user-attachments/assets/5584c386-28f7-407b-96bb-97c3629c4fef)

3. Comments

# DoD:

- [x] semantic layout

- [ ] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
