### PR TITLE
add test to signin page

### DIFF
--- a/src/app/signIn/SignIn.test.tsx
+++ b/src/app/signIn/SignIn.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SignIn from './page';
+import { customRender } from '@/utils/CustomeRenderTest';
+import { usePathname } from 'next/navigation';
+
+describe('SignUp Page', () => {
+  it('renders the RegistrationForm and handles a successful registration', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/signIn');
+
+    customRender(<SignIn />, { token: null });
+
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByTestId('password');
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+
+    expect(emailInput).toBeInTheDocument();
+    expect(passwordInput).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123!' } });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            token: 'mockToken',
+            uid: 'mockedUID',
+          }),
+      }),
+    ) as jest.Mock;
+
+    await act(async () => {
+      fireEvent.submit(submitButton);
+    });
+  });
+});

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -26,8 +26,6 @@ export const LoginForm: React.FC = () => {
         router.replace('/');
         const userData = await readUserData(user.uid);
         updateUserName(userData.username);
-      } else {
-        //TODO
       }
     } catch (error) {
       //TODO


### PR DESCRIPTION
1. Acceptance criteria:

- coverage > 80%
-

2. Screenshot min and max layout (not technical tasks): 
<img width="922" alt="image" src="https://github.com/user-attachments/assets/1ad4fdfc-0cbd-4d12-8a84-82bc6d4fd5f1">
<img width="989" alt="image" src="https://github.com/user-attachments/assets/625c7cb1-d09a-439f-a83a-df865f9cb633">
<img width="861" alt="image" src="https://github.com/user-attachments/assets/47b4e683-24ad-4e3c-8957-bd82ebe15643">


3. Comments: total coverage was 67.5 but after comments = 67.36, coverage (was decreased bc of comments to PR), see the last screenshot. It means we can improve coverage in future after implementing logic within else statement. 

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
