### PR TITLE
add singout page to redirect to main if token expired

### DIFF
--- a/src/app/signOut/page.tsx
+++ b/src/app/signOut/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useAuth } from '@/hooks/useAuth';
+import { useRouter } from 'next/navigation';
+
+export default function SingOut() {
+  const { updateToken, logout } = useAuth();
+  const router = useRouter();
+
+  router.replace('/');
+  updateToken('');
+  logout();
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -16,7 +16,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children, initialTok
   const [userName, setUserName] = useState<string | null>(null);
 
   const updateToken = (newToken: string) => {
-    setToken(newToken);
+    if (!newToken) {
+      setToken(null);
+    } else {
+      setToken(newToken);
+    }
   };
 
   const updateUserName = (newName: string) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(req: NextRequest) {
     const isAllowed = allowedMethodsRegex.test(pathname);
 
     if (isAllowed) {
-      return NextResponse.redirect(new URL('/signIn', req.url));
+      return NextResponse.redirect(new URL('/signOut', req.url));
     }
   }
 
@@ -35,6 +35,7 @@ export const config = {
   matcher: [
     '/signIn',
     '/signUp',
+    '/signOut',
     '/GET/:path*',
     '/POST/:path*',
     '/PUT/:path*',


### PR DESCRIPTION
1. Acceptance criteria:

- redirect to Main from RestClient and History if user press any button/link
-

2. Screenshot min and max layout (not technical tasks):
3. Comments: no autoredirect after token expired, redirect doesn't work from GraphiQl to welcome 

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
