### PR TITLE
fix language sync with localstorage

### DIFF
--- a/src/components/header/language/Languages.tsx
+++ b/src/components/header/language/Languages.tsx
@@ -1,20 +1,37 @@
-import React, { startTransition } from 'react';
 import style from '@/components/header/language/Language.module.scss';
-import { Locale } from '@/config';
+import React, { startTransition, useEffect, useState } from 'react';
+import Cookies from 'js-cookie';
 import { setUserLocale } from '@/services/locale';
+import { Locale } from '@/config';
 
 export const Languages: React.FC = () => {
-  const toggleLanguage = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const locale = e.currentTarget.value as Locale;
+  const [selectedLanguage, setSelectedLanguage] = useState<string>('en');
+
+  const toggleLanguage = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newLanguage = event.currentTarget.value as Locale;
 
     startTransition(() => {
-      setUserLocale(locale);
+      setUserLocale(newLanguage);
     });
+    setSelectedLanguage(newLanguage);
+    Cookies.set('NEXT_LOCALE', newLanguage);
   };
+
+  useEffect(() => {
+    const savedLanguage = Cookies.get('NEXT_LOCALE');
+    if (savedLanguage) {
+      setSelectedLanguage(savedLanguage);
+    }
+  }, []);
 
   return (
     <div className={style.language}>
-      <select onChange={toggleLanguage} className={style.selectWrap} id="languageselect">
+      <select
+        value={selectedLanguage}
+        onChange={toggleLanguage}
+        className={style.selectWrap}
+        id="languageselect"
+      >
         <option value="en" data-testid="en-option">
           English
         </option>


### PR DESCRIPTION
1. Acceptance criteria:

after refresh:

- page should be displayed according to language from local storage

- language switcher should be according to language from local storage

2. Screenshot min and max layout (not technical tasks):
3. Comments

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections