### PR TITLE
fix layout graphiql

### DIFF
--- a/src/components/graphClient/GraphClient.module.scss
+++ b/src/components/graphClient/GraphClient.module.scss
@@ -16,16 +16,27 @@
 
 .graphContainer {
   display: flex;
-  margin-top: 20px;
+  flex-direction: row;
+  gap: 20px;
+  margin: 15px 0;
+  padding: 0 10px;
 
-  @media (width < 1100px) {
+  @media (width < 800px) {
     flex-direction: column;
+
+    .response {
+      padding: 0 10px;
+    }
+
   }
+
 }
 
 .response {
   border: 1px solid red;
-  width: 50%;
+  width: auto;
+  flex-grow: 0.5;
+  height: 150px;
 }
 
 .error {
@@ -42,6 +53,7 @@
     flex-direction: column;
     width: 45%;
     margin-left: 50px;
+
   }
 
   @media (width < 500px) {

--- a/src/components/graphiRequest/GraphiRequest.module.scss
+++ b/src/components/graphiRequest/GraphiRequest.module.scss
@@ -1,20 +1,14 @@
 .wrapper {
-  width: 50%;
-
-  @media (width < 1100px) {
-    width: 100%;
-  }
+  width: auto;
+  flex-grow: 0.5;
 }
 
 .inputContainer {
-  width: 90%;
   display: flex;
   gap: 20px;
   flex-direction: column;
 
-  @media (width < 1100px) {
-    align-items: center;
-  }
+
 }
 
 .urlInput,
@@ -24,7 +18,14 @@
   gap: 5px;
   font-size: 1.6rem;
 
-  @media (width < 1100px) {
-    width: 80%;
+  @media(width<450px) {
+    font-size: 1.1rem;
   }
+
+  >input {
+    @media(width<450px) {
+      font-size: 1.1rem;
+    }
+  }
+
 }


### PR DESCRIPTION
1. Acceptance criteria:

- Responsive layout >=380 px

2. Screenshot min and max layout (not technical tasks): 
![image](https://github.com/user-attachments/assets/7a7d7b78-23d5-4560-9afd-8011edbb05c5)
![image](https://github.com/user-attachments/assets/4a2ba3ec-785c-49ae-99ea-99f3d14a5260)

3. Comments

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
