### PR TITLE
fix: remove number zero when history empty

### DIFF
--- a/src/app/history/History.module.scss
+++ b/src/app/history/History.module.scss
@@ -10,6 +10,7 @@
   max-height: 80vh;
   border: 1px solid #cdcdcd;
   background-color: #f5f5f5b5;
+  padding: 10px;
 
   > h1 {
     text-transform: uppercase;

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -16,7 +16,7 @@ export default function History() {
 
   return (
     <section className={style.wrapper}>
-      {request.length && (
+      {request.length > 0 && (
         <>
           <h1>{t('history requests')}</h1>
           <div className={style.table}>
@@ -40,7 +40,7 @@ export default function History() {
           </div>
         </>
       )}
-      {!requests.length && (
+      {requests.length === 0 && (
         <>
           <div className={style.norequest}>
             <p>{`You haven't executed any requests yet.`}</p>


### PR DESCRIPTION
1. Acceptance criteria:
- remove number zero when history is empty

2. Screenshot min and max layout (not technical tasks):
before:
![Zrzut ekranu 2024-09-23 163709](https://github.com/user-attachments/assets/2b6a4a42-87a9-432b-bc89-d256e91ce1f3)

after:
![Zrzut ekranu 2024-09-23 164137](https://github.com/user-attachments/assets/5022eb75-99e2-4306-b4fe-1ee7e217d030)


3. Comments

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
