### PR TITLE
fix: add line between header and var

### DIFF
--- a/messages/fr.json
+++ b/messages/fr.json
@@ -14,12 +14,12 @@
     "back": "Retour à la page d'accueil"
   },
   "Clients": {
-    "restfull client": "Client RESTful",
+    "restfull client": "RESTfull client",
     "send": "Envoyer",
     "header": "en-tête",
     "variable": "variable",
-    "add en-tête": "Ajouter un en-tête",
-    "add variable": "Ajouter une variable",
+    "add en-tête": "Ajouter En-tête",
+    "add variable": "Ajouter Variable",
     "enter endpoint URL": "Saisir l'URL du point de terminaison",
     "enter SDL endpoint URL": "Saisir l'URL du point de terminaison SDL",
     "get documentation": "OBTENIR LA DOCUMENTATION",

--- a/messages/it.json
+++ b/messages/it.json
@@ -14,12 +14,12 @@
     "back": "Torna alla pagina di benvenuto"
   },
   "Clients": {
-    "restfull client": "Client RESTful",
+    "restfull client": "RESTfull client",
     "send": "Invia",
     "header": "intestazione",
     "variable": "variabile",
-    "add intestazione": "Aggiungi intestazione",
-    "add variabile": "Aggiungi variabile",
+    "add intestazione": "Aggiungi Intestazione",
+    "add variabile": "Aggiungi Variabile",
     "enter endpoint URL": "Inserisci l'URL del punto di accesso",
     "enter SDL endpoint URL": "Inserisci l'URL del punto di accesso SDL",
     "get documentation": "OTTENERE DOCUMENTAZIONE",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -14,13 +14,12 @@
     "back": "Powrót do strony powitalnej"
   },
   "Clients": {
-    "restfull client": "Klient RESTful",
+    "restfull client": "RESTfull klient",
     "send": "Wyślij",
     "header": "nagłówek",
     "variable": "zmienna",
-    "add header": "Dodaj nagłówek",
-    "add nagłówek": "Dodaj nagłówek",
-    "add zmienna": "Dodaj zmienną",
+    "add nagłówek": "Dodaj Nagłówek",
+    "add zmienna": "Dodaj Zmienną",
     "enter endpoint URL": "Wprowadź URL punktu końcowego",
     "enter SDL endpoint URL": "Wprowadź URL punktu końcowego SDL",
     "get documentation": "POBIERZ DOKUMENTACJĘ",

--- a/src/components/restClient/RestClient.module.scss
+++ b/src/components/restClient/RestClient.module.scss
@@ -78,6 +78,13 @@
   outline: none;
 }
 
+.line {
+  border-bottom: 1px dashed #cdcdcd;
+  width: 100%;
+  height: auto;
+  margin: 1px;
+}
+
 @media (width <=500px) {
   .container {
     width: auto;

--- a/src/components/restClient/RestClient.tsx
+++ b/src/components/restClient/RestClient.tsx
@@ -228,6 +228,8 @@ export default function RestClient({
           updateUrlWithoutRedirect={updateUrlWithoutRedirect}
         />
 
+        <div className={style.line}></div>
+
         <Editor
           headers={variables}
           handleAddHeader={handleAddVariable}


### PR DESCRIPTION
1. Acceptance criteria:
- add line between header and var

2. Screenshot min and max layout (not technical tasks):
![Zrzut ekranu 2024-09-23 175512](https://github.com/user-attachments/assets/f66050c5-6a03-42a2-8ab8-efe624b7f803)

3. Comments

# DoD:

- [x] semantic layout

- [x] test coverage >= 80%

- [x] no more than 2 fonts per page, font size >= 14 px, optimal font and background contrast

- [x] adaptive layout, the minimum page width of the application should be 380px

- [x] interactivity of elements users can interact with; element hover effects; usage of different styles for the active and inactive state of the element; smooth animations

- [x] the same fonts, button styles, indents, and the same elements on all pages of the application have the same appearance and layout.

- [x] item colors and background images may vary. In this case, colors should be from the same palette, and background images from the same collection.

- [x] internationalization (i18n) - 2 languages

- [x] ABSENCE of errors and warnings in the console

- [x] ABSENCE in the console of the results of the console.log execution

- [x] ABSENCE or any usage of @ts-ignore (search through GitHub repo)

- [x] ABSENCE of code-smells (God-object, chunks of duplicate code), commented code sections
